### PR TITLE
Support config args in the command line

### DIFF
--- a/mpfmonitor/commands/monitor.py
+++ b/mpfmonitor/commands/monitor.py
@@ -40,8 +40,7 @@ class Command(object):
                             help="The name of a config file to load. Note "
                                  "this is a config for the monitor itself, "
                                  "not an MPF config.yaml. Default is "
-                                 "monitor.yaml. Multiple files can be used "
-                                 "via a comma-separated list (no spaces between)")
+                                 "monitor.")
 
         parser.add_argument("-v",
                             action="store_const", dest="loglevel", const=logging.DEBUG,
@@ -63,8 +62,7 @@ class Command(object):
                                  "folder>/mpfmonitor.yaml")
 
         args = parser.parse_args(args)
-
-        args.configfile = Util.string_to_list(args.configfile)
+        args.configfile = "{}.yaml".format(args.configfile)
 
         # Configure logging. Creates a logfile and logs to the console.
         # Formatting options are documented here:
@@ -103,7 +101,7 @@ class Command(object):
         thread_stopper = threading.Event()
 
         try:
-            run(machine_path=machine_path, thread_stopper=thread_stopper)
+            run(machine_path=machine_path, thread_stopper=thread_stopper, config_file=args.configfile)
             logging.info("MPF Monitor run loop ended.")
         except Exception as e:
             logging.exception(str(e))

--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -25,7 +25,7 @@ from mpfmonitor.core.inspector import InspectorWindow
 
 
 class MPFMonitor():
-    def __init__(self, app, machine_path, thread_stopper, parent=None, testing=False):
+    def __init__(self, app, machine_path, thread_stopper, config_file, parent=None, testing=False):
 
         # super().__init__(parent)
 
@@ -43,7 +43,7 @@ class MPFMonitor():
         self.config = None
         self.layout = None
         self.config_file = os.path.join(self.machine_path, "monitor",
-                                        "monitor.yaml")
+                                        config_file)
         self.playfield_image_file = os.path.join(self.machine_path,
                                                  "monitor", "playfield.jpg")
 
@@ -293,5 +293,5 @@ class MPFMonitor():
 def run(machine_path, thread_stopper, testing=False):
 
     app = QApplication(sys.argv)
-    MPFMonitor(app, machine_path, thread_stopper, testing=testing)
+    MPFMonitor(app, machine_path, thread_stopper, config_file, testing=testing)
     app.exec_()

--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -290,7 +290,7 @@ class MPFMonitor():
 
 
 
-def run(machine_path, thread_stopper, testing=False):
+def run(machine_path, thread_stopper, config_file, testing=False):
 
     app = QApplication(sys.argv)
     MPFMonitor(app, machine_path, thread_stopper, config_file, testing=testing)


### PR DESCRIPTION
This PR updates mpf monitor to support the `-c` command line argument for config files. Currently, monitor is hard-coded to use _monitor/monitor.yaml_ as the config file for monitor.

The MPF Show Creator uses the monitor config to determine the placement of lights on the playfield, but has no option to disable or filter the lights. For creating shows that use only some of the lights, different monitor config files are needed to position the desired lights.

_Example:_
```
mpf monitor -c monitor_playfield_gi_only
```

MPF already supports `-c` as an argument for config files, so this PR extends the pattern for MPF Monitor. If no arg is provided, the default _monitor.yaml_ will be used.