### PR TITLE
Checks variable type before updating

### DIFF
--- a/mpfmonitor/core/variables.py
+++ b/mpfmonitor/core/variables.py
@@ -21,6 +21,7 @@ class VariableWindow(QWidget):
         self.added_index = 0
 
         self.variables = {}
+        self.variables_type = {}
 
     def draw_ui(self):
         # Load ui file from ./ui/
@@ -72,9 +73,10 @@ class VariableWindow(QWidget):
 
     def update_variable(self, type, variable, value):
         """Update variables."""
-        if variable in self.variables:
+        if variable in self.variables and type == self.variables_type[variable]:
             self.variables[variable].setData(str(value), Qt.DisplayRole)
         else:
+            self.variables_type[variable] = type
             value_model = QStandardItem(str(value))
             self.variables[variable] = value_model
             self.model.insertRow(0, [QStandardItem(type), QStandardItem(str(variable)), value_model])


### PR DESCRIPTION
This verifies that the variable type matches before updating.  Currently
it only checks the name, and then updates the value.  For instance, if
you have a machine variable, but accidently use set instead of
set_machine, the variables pane will show the updated value, but its not
actually updated because it created a player variable with that name in
the actual runtime.  This creates a new dictionary to tie the varaible
to the type, and then verifies the variable exists of the correct type
before updating a row.  Otherwise it will enter it.  In this case you
would have two variables named the same, one of type machine, and one of
type player.