### PR TITLE
Fixes Drawing of Flipper Shape

### DIFF
--- a/mpfmonitor/core/playfield.py
+++ b/mpfmonitor/core/playfield.py
@@ -271,8 +271,8 @@ class PfWidget(QGraphicsItem):
             scale = .7
             points = QPolygon([
                 QPoint(0, int(self.device_size * scale * -1)),
-                QPoint(int(self.device_size * scale * -1), ((int(self.device_size * scale) / 2) * aspect_ratio)),
-                QPoint(int(self.device_size * scale), ((int(self.device_size * scale) / 2) * aspect_ratio)),
+                QPoint(int(self.device_size * scale * -1), (int((self.device_size * scale) / 2) * aspect_ratio)),
+                QPoint(int(self.device_size * scale), (int((self.device_size * scale) / 2) * aspect_ratio)),
             ])
             painter.drawPolygon(points)
 


### PR DESCRIPTION
The int was inside the wrong set or parentheses, which broke monitor when it tried to load.