### PR TITLE
Python 3.13 support

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -12,34 +12,61 @@ jobs:
         include:
         - os: windows-latest
           python-version: 3.8
+          mpf-version: 0.57.3
         - os: windows-latest
           python-version: 3.9
+          mpf-version: 0.57.3
         - os: windows-latest
           python-version: '3.10'
+          mpf-version: 0.57.3
         - os: windows-latest
           python-version: '3.11'
+          mpf-version: 0.57.3
         - os: windows-latest
           python-version: '3.12'
+          mpf-version: 0.57.3
+
         - os: ubuntu-24.04
           python-version: 3.8
+          mpf-version: 0.57.3
         - os: ubuntu-24.04
           python-version: 3.9
+          mpf-version: 0.57.3
         - os: ubuntu-24.04
           python-version: '3.10'
+          mpf-version: 0.57.3
         - os: ubuntu-24.04
           python-version: '3.11'
+          mpf-version: 0.57.3
         - os: ubuntu-24.04
           python-version: '3.12'
+          mpf-version: 0.57.3
+
         - os: macos-latest
           python-version: 3.8
+          mpf-version: 0.57.3
         - os: macos-latest
           python-version: 3.9
+          mpf-version: 0.57.3
         - os: macos-latest
           python-version: '3.10'
+          mpf-version: 0.57.3
         - os: macos-latest
           python-version: '3.11'
+          mpf-version: 0.57.3
         - os: macos-latest
           python-version: '3.12'
+          mpf-version: 0.57.3
+
+        - os: windows-latest
+          python-version: '3.13'
+          mpf-version: 0.80.0.dev11
+        - os: ubuntu-24.04
+          python-version: '3.13'
+          mpf-version: 0.80.0.dev11
+        - os: macos-latest
+          python-version: '3.13'
+          mpf-version: 0.80.0.dev11
 
     steps:
       - name: Checkout mpf-monitor
@@ -60,7 +87,7 @@ jobs:
       - name: Install mpf-monitor
         run: |
           pip install --upgrade pip setuptools wheel build coveralls
-          pip install 'mpf>=0.57.0'
+          pip install mpf==${{ matrix.mpf-version }}
           pip install -e .
 
       - name: Lint with flake8
@@ -116,7 +143,7 @@ jobs:
           sudo apt-get install -y '^libxcb.*-dev' libx11-xcb-dev libjpeg-dev
           sudo apt-get install -y qt6-base-dev
           pip install --upgrade pip setuptools wheel build
-          pip install 'mpf>=0.57.0'
+          pip install mpf==0.57.3
           pip install -e .
 
       - name: Build wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -25,6 +26,7 @@ classifiers=[
 dependencies = [
     # Deps that MPF Monitor needs that MPF also needs are not included here
     "PyQt6 >= 6.4.2",  # Sept 19, 2023
+    "Pillow >= 10.4.0",  # Dec 7, 2025
     ]
 dynamic = ["version"]
 


### PR DESCRIPTION
MPF .57 doesn't support Python 3.13, but .80 does, so monitor upgrading support for Python 3.13+ still has relevance even if .57 will slowly deprecate