### PR TITLE
Change QSettings from mpf monitor to a set path (/monitor) and file n…

### DIFF
--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -46,8 +46,11 @@ class MPFMonitor():
                                         config_file)
         self.playfield_image_file = os.path.join(self.machine_path,
                                                  "monitor", "playfield.jpg")
+        self.settings_file = os.path.join(self.machine_path,
+                                                 "monitor", "settings.ini")
 
-        self.local_settings = QSettings("mpf", "mpf-monitor")
+        QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+        self.local_settings = QSettings(self.settings_file, QSettings.Format.IniFormat)
 
         self.load_config()
 


### PR DESCRIPTION
Change QSettings from "mpf, monitor" to a set path off the machine path (/monitor) and file name (setings.ini).

Resolving open issue: https://github.com/missionpinball/mpf-monitor/issues/33

Don't recommend mixing yaml files and setting files as a solution.