### PR TITLE
Implemented remote MPF Monitor CLI and setting option

### DIFF
--- a/mpfmonitor/commands/monitor.py
+++ b/mpfmonitor/commands/monitor.py
@@ -64,6 +64,11 @@ class Command(object):
                             help="The MPF Monitor default config file. "
                                  "Default is <mpf-monitor install "
                                  "folder>/mpfmonitor.yaml")
+        
+        parser.add_argument("-ip",
+                            action="store", dest="mpfipaddr",
+                            help="The MPF IP Address "
+                                 "Default is localhost ")
 
         args = parser.parse_args(args)
         args.configfile = "{}.yaml".format(args.configfile)
@@ -105,7 +110,7 @@ class Command(object):
         thread_stopper = threading.Event()
 
         try:
-            run(machine_path=machine_path, thread_stopper=thread_stopper, config_file=args.configfile)
+            run(machine_path=machine_path, thread_stopper=thread_stopper, config_file=args.configfile, ip_addr=args.mpfipaddr)
             logging.info("MPF Monitor run loop ended.")
         except Exception as e:
             logging.exception(str(e))

--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -25,7 +25,7 @@ from mpfmonitor.core.variables import VariableWindow
 
 
 class MPFMonitor():
-    def __init__(self, app, machine_path, thread_stopper, config_file, parent=None, testing=False):
+    def __init__(self, app, machine_path, thread_stopper, config_file, ip_addr=None, parent=None, testing=False):
 
         # super().__init__(parent)
 
@@ -42,6 +42,7 @@ class MPFMonitor():
         self.app = app
         self.config = None
         self.layout = None
+        self.mpf_ip_addr = ip_addr
         self.config_file = os.path.join(self.machine_path, "monitor",
                                         config_file)
         self.playfield_image_file = os.path.join(self.machine_path,
@@ -60,8 +61,12 @@ class MPFMonitor():
         if not isinstance(self.pf_device_size, float):  # Protect against corrupted device size
             self.pf_device_size = .02
 
+        #Command line takes priority over settings file. If command line is None, then read the settings file.
+        if (self.mpf_ip_addr == None):            
+            #if mpf_ip_address is not in the settings file, then localhost will be used
+            self.mpf_ip_addr = self.local_settings.value("settings/mpf-ip-address", "localhost")
         self.bcp = BCPClient(self, self.receive_queue,
-                             self.sending_queue, 'localhost', 5051,
+                             self.sending_queue, self.mpf_ip_addr, 5051,
                              simulate=testing, cache=False)
 
         self.tick_timer = QTimer(self.device_window)
@@ -324,8 +329,8 @@ class MPFMonitor():
 
 
 
-def run(machine_path, thread_stopper, config_file, testing=False):
+def run(machine_path, thread_stopper, config_file, ip_addr="localhost", testing=False):
 
     app = QApplication(sys.argv)
-    MPFMonitor(app, machine_path, thread_stopper, config_file, testing=testing)
+    MPFMonitor(app, machine_path, thread_stopper, config_file, ip_addr, testing=testing)
     app.exec()


### PR DESCRIPTION
Updated MPF Monitor to accept command line argument -ip to specify an ip address of the BCP Server to connect to. Also can specify a setting 'mpf-ip-address' in settings.ini under [settings]. CLI will take priority. If CLI nor settings.ini entry is available, will default to 'localhost'.

MPF already has a setting under bpc: servers: uri_style: ip: that if updated from 127.0.0.1 to 0.0.0.0 or other ip address, will open a  port for the MPF Monitor to connect remotely to.