### PR TITLE
add -port argument to accompany -ip arg for specifying MPF server addresses other than localhost:5051

### DIFF
--- a/mpfmonitor/commands/monitor.py
+++ b/mpfmonitor/commands/monitor.py
@@ -15,7 +15,6 @@ from mpfmonitor._version import __version__
 # import functiontrace
 # functiontrace.trace()
 
-
 class Command(object):
 
     # pylint: disable-msg=too-many-locals
@@ -64,11 +63,14 @@ class Command(object):
                             help="The MPF Monitor default config file. "
                                  "Default is <mpf-monitor install "
                                  "folder>/mpfmonitor.yaml")
-        
+
         parser.add_argument("-ip",
                             action="store", dest="mpfipaddr",
-                            help="The MPF IP Address "
-                                 "Default is localhost ")
+                            help="The MPF IP Address Default is localhost")
+
+        parser.add_argument("-port",
+                            action="store", dest="mpfport",
+                            help="The MPF Port Default is 5051")
 
         args = parser.parse_args(args)
         args.configfile = "{}.yaml".format(args.configfile)
@@ -110,7 +112,11 @@ class Command(object):
         thread_stopper = threading.Event()
 
         try:
-            run(machine_path=machine_path, thread_stopper=thread_stopper, config_file=args.configfile, ip_addr=args.mpfipaddr)
+            run(machine_path=machine_path,
+                thread_stopper=thread_stopper,
+                config_file=args.configfile,
+                ip_addr=args.mpfipaddr,
+                port=args.mpfport)
             logging.info("MPF Monitor run loop ended.")
         except Exception as e:
             logging.exception(str(e))
@@ -126,7 +132,6 @@ class Command(object):
         logging.info("All child threads stopped.")
 
         sys.exit()
-
 
 def get_command():
     return 'monitor', Command

--- a/mpfmonitor/core/bcp_client.py
+++ b/mpfmonitor/core/bcp_client.py
@@ -66,7 +66,7 @@ class BCPClient(object):
                 self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 try:
-                    self.socket.connect((self.interface, self.port))
+                    self.socket.connect((self.interface, int(self.port)))
                     self.socket.settimeout(0.1) # Set a small timeout for non-blocking operations
                     self.connected = True
                     self.log.info("Connected to MPF.")

--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -13,8 +13,6 @@ from PyQt6.QtWidgets import *
 
 from ruamel import yaml
 
-
-
 from mpfmonitor.core.devices import *
 from mpfmonitor.core.playfield import *
 from mpfmonitor.core.bcp_client import BCPClient
@@ -23,9 +21,13 @@ from mpfmonitor.core.modes import ModeWindow
 from mpfmonitor.core.inspector import InspectorWindow
 from mpfmonitor.core.variables import VariableWindow
 
+def run(machine_path, thread_stopper, config_file, ip_addr="localhost", port="5051", testing=False):
+    app = QApplication(sys.argv)
+    MPFMonitor(app, machine_path, thread_stopper, config_file, ip_addr, port, testing=testing)
+    app.exec()
 
 class MPFMonitor():
-    def __init__(self, app, machine_path, thread_stopper, config_file, ip_addr=None, parent=None, testing=False):
+    def __init__(self, app, machine_path, thread_stopper, config_file, ip_addr=None, port=None, parent=None, testing=False):
 
         # super().__init__(parent)
 
@@ -43,6 +45,7 @@ class MPFMonitor():
         self.config = None
         self.layout = None
         self.mpf_ip_addr = ip_addr
+        self.mpf_port = port
         self.config_file = os.path.join(self.machine_path, "monitor",
                                         config_file)
         self.playfield_image_file = os.path.join(self.machine_path,
@@ -62,11 +65,17 @@ class MPFMonitor():
             self.pf_device_size = .02
 
         #Command line takes priority over settings file. If command line is None, then read the settings file.
-        if (self.mpf_ip_addr == None):            
-            #if mpf_ip_address is not in the settings file, then localhost will be used
+
+        #if mpf_ip_address is not in the settings file, then localhost will be used
+        if (self.mpf_ip_addr == None):
             self.mpf_ip_addr = self.local_settings.value("settings/mpf-ip-address", "localhost")
+
+        #if mpf_port is not in the settings file, then 5051 will be used
+        if (self.mpf_port == None):
+            self.mpf_port = self.local_settings.value("settings/mpf-port", "5051")
+
         self.bcp = BCPClient(self, self.receive_queue,
-                             self.sending_queue, self.mpf_ip_addr, 5051,
+                             self.sending_queue, self.mpf_ip_addr, self.mpf_port,
                              simulate=testing, cache=False)
 
         self.tick_timer = QTimer(self.device_window)
@@ -324,13 +333,3 @@ class MPFMonitor():
     def set_inspector_mode(self, enabled=False):
         self.inspector_enabled = enabled
         self.view.set_inspector_mode_title(inspect=enabled)
-
-
-
-
-
-def run(machine_path, thread_stopper, config_file, ip_addr="localhost", testing=False):
-
-    app = QApplication(sys.argv)
-    MPFMonitor(app, machine_path, thread_stopper, config_file, ip_addr, testing=testing)
-    app.exec()


### PR DESCRIPTION
Accompanies https://github.com/missionpinball/mpf-monitor/pull/56 to provide remote connection specification for networked monitor instances