### PR TITLE
Hid extra clear buttons in modes and variables.

### DIFF
--- a/mpfmonitor/core/modes.py
+++ b/mpfmonitor/core/modes.py
@@ -24,6 +24,7 @@ class ModeWindow(QWidget):
         # Load ui file from ./ui/
         ui_path = os.path.join(os.path.dirname(__file__), "ui", "searchable_table.ui")
         self.ui = uic.loadUi(ui_path, self)
+        self.ui.clear_button.hide()
 
         self.ui.setWindowTitle('Running Modes')
 

--- a/mpfmonitor/core/variables.py
+++ b/mpfmonitor/core/variables.py
@@ -26,6 +26,7 @@ class VariableWindow(QWidget):
         # Load ui file from ./ui/
         ui_path = os.path.join(os.path.dirname(__file__), "ui", "searchable_table.ui")
         self.ui = uic.loadUi(ui_path, self)
+        self.ui.clear_button.hide()
 
         self.ui.setWindowTitle('Player/Machine Variables')
 


### PR DESCRIPTION
Called hide in modes.py and variables.py. Makes it look like it was never there.