### PR TITLE
draw outline of devices that have enabled properties as red or green to match

### DIFF
--- a/mpfmonitor/core/devices.py
+++ b/mpfmonitor/core/devices.py
@@ -92,6 +92,13 @@ class DeviceNode:
     def type(self):
         return self._type
 
+    def get_colored_pen(self):
+        if 'enabled' in self.data():
+            color = Qt.GlobalColor.green if self.data()['enabled'] else Qt.GlobalColor.red
+            return QPen(color, 3, Qt.PenStyle.SolidLine)
+        else:
+            return QPen(Qt.GlobalColor.white, 3, Qt.PenStyle.SolidLine)
+
     def get_colored_brush(self) -> QBrush:
         """Return colored brush for device."""
         return self._brush

--- a/mpfmonitor/core/playfield.py
+++ b/mpfmonitor/core/playfield.py
@@ -148,7 +148,6 @@ class PfWidget(QGraphicsItem):
         self.update_pos(save)
         self.click_start = 0
         self.release_switch = False
-        self.pen = QPen(Qt.GlobalColor.white, 3, Qt.PenStyle.SolidLine)
 
         self.log = logging.getLogger('Core')
 
@@ -242,7 +241,7 @@ class PfWidget(QGraphicsItem):
     def paint(self, painter, option, widget=None):
         """Paint this widget to the playfield."""
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
-        painter.setPen(self.pen)
+        painter.setPen(self.widget.get_colored_pen())
         painter.setBrush(self.widget.get_colored_brush())
 
         draw_shape = self.draw_shape()


### PR DESCRIPTION
This is not terribly useful on devices that report "enabled" in the first position, as the black/white fill is determined by the first property. This is useful though for diverters and multiballs and some others that report enabled in a later position.