### PR TITLE
Support more customizations

### DIFF
--- a/mpfmonitor/commands/monitor.py
+++ b/mpfmonitor/commands/monitor.py
@@ -45,6 +45,15 @@ class Command(object):
                                  "not an MPF config.yaml. Default is "
                                  "monitor.")
 
+        parser.add_argument("-i",
+                            action="store", dest="image_file",
+                            default="playfield.jpg",
+                            metavar='image_file',
+                            help="The MPF Monitor image file name. "
+                                 "Files must be placed within the folder '<game>/monitor/' "
+                                 "Default is playfield.jpg\n"
+                                 "Supported types: PNG, JPG, BMP, GIF")
+
         parser.add_argument("-v",
                             action="store_const", dest="loglevel", const=logging.DEBUG,
                             default=logging.INFO, help="Enables verbose logging to the"
@@ -115,6 +124,7 @@ class Command(object):
             run(machine_path=machine_path,
                 thread_stopper=thread_stopper,
                 config_file=args.configfile,
+                image_file=args.image_file,
                 ip_addr=args.mpfipaddr,
                 port=args.mpfport)
             logging.info("MPF Monitor run loop ended.")

--- a/mpfmonitor/core/devices.py
+++ b/mpfmonitor/core/devices.py
@@ -8,23 +8,17 @@ from PyQt6.QtGui import *
 from PyQt6.QtWidgets import *
 from PyQt6 import uic
 
-BRUSH_WHITE = QBrush(QColor(255, 255, 255), Qt.BrushStyle.SolidPattern)
-BRUSH_GREEN = QBrush(QColor(0, 255, 0), Qt.BrushStyle.SolidPattern)
-BRUSH_BLACK = QBrush(QColor(0, 0, 0), Qt.BrushStyle.SolidPattern)
-BRUSH_DARK_PURPLE = QBrush(QColor(128, 0, 255), Qt.BrushStyle.SolidPattern)
-
 
 class DeviceNode:
 
-    __slots__ = ["_callback", "_name", "_data", "_type", "_brush", "q_name", "q_state", "sub_properties",
-                 "sub_properties_appended", "q_time_added", "log"]
+    __slots__ = ["_callback", "_name", "_data", "_type", "q_name", "q_state",
+                 "sub_properties", "sub_properties_appended", "q_time_added", "log"]
 
     def __init__(self):
         self._callback = None
         self._name = ""
         self._data = {}
         self._type = ""
-        self._brush = BRUSH_BLACK
 
         self.q_name = QStandardItem()
         self.q_state = QStandardItem()
@@ -76,11 +70,9 @@ class DeviceNode:
 
         self.sub_properties_appended = True
         self.q_state.emitDataChanged()
-        self._brush = self._calculate_colored_brush()
 
     def setType(self, type):
         self._type = type
-        self._brush = self._calculate_colored_brush()
         self.q_state.emitDataChanged()
 
     def get_row(self):
@@ -92,16 +84,13 @@ class DeviceNode:
     def type(self):
         return self._type
 
-    def get_colored_pen(self):
-        if 'enabled' in self.data():
-            color = Qt.GlobalColor.green if self.data()['enabled'] else Qt.GlobalColor.red
-            return QPen(color, 3, Qt.PenStyle.SolidLine)
-        else:
-            return QPen(Qt.GlobalColor.white, 3, Qt.PenStyle.SolidLine)
+    def get_colored_pen(self, outline):
+        """Return colored pen for device."""
+        return self._calculate_colored_pen(outline)
 
-    def get_colored_brush(self) -> QBrush:
+    def get_colored_brush(self, alpha) -> QBrush:
         """Return colored brush for device."""
-        return self._brush
+        return self._calculate_colored_brush(alpha)
 
     def _calculate_color_gamma_correction(self, color):
         """Perform gamma correction.
@@ -126,38 +115,47 @@ class DeviceNode:
 
         return corrected
 
-    def _calculate_colored_brush(self):
+    def _calculate_colored_pen(self, outline):
+        data = self.data()
+        if 'enabled' in data:
+            color = Qt.GlobalColor.green if data['enabled'] else Qt.GlobalColor.red
+            return QPen(color, outline + 1, Qt.PenStyle.SolidLine)
+        else:
+            return QPen(Qt.GlobalColor.white, outline, Qt.PenStyle.SolidLine)
+
+    def _calculate_colored_brush(self, alpha):
+        data = self.data()
+
         if self._type == 'light':
-            color = self.data()['color']
+            color = data['color']
             if color == [0, 0, 0]:
-                # shortcut for black
-                return BRUSH_BLACK
+                return QBrush(QColor(0, 0, 0, alpha), Qt.BrushStyle.SolidPattern)
             color = self._calculate_color_gamma_correction(color)
 
         elif self._type == 'switch':
-            state = self.data()['state']
+            state = data['state']
 
             if state:
-                return BRUSH_GREEN
+                return QBrush(QColor(0, 255, 0, alpha), Qt.BrushStyle.SolidPattern)
             else:
-                return BRUSH_BLACK
+                return QBrush(QColor(0, 0, 0, alpha), Qt.BrushStyle.SolidPattern)
 
         elif self._type == 'diverter':
-            state = self.data()['active']
+            state = data['active']
 
             if state:
-                return BRUSH_DARK_PURPLE
+                return QBrush(QColor(128, 0, 255, alpha), Qt.BrushStyle.SolidPattern)
             else:
-                return BRUSH_BLACK
+                return QBrush(QColor(0, 0, 0, alpha), Qt.BrushStyle.SolidPattern)
         else:
             # Get first parameter and draw as white if it evaluates True
-            state = bool(list(self.data().values())[0])
+            state = bool(list(data.values())[0])
             if state:
-                return BRUSH_WHITE
+                return QBrush(QColor(255, 255, 255, alpha), Qt.BrushStyle.SolidPattern)
             else:
-                return BRUSH_BLACK
+                return QBrush(QColor(0, 0, 0, alpha), Qt.BrushStyle.SolidPattern)
 
-        return QBrush(QColor(*color), Qt.BrushStyle.SolidPattern)
+        return QBrush(QColor(*color, alpha), Qt.BrushStyle.SolidPattern)
 
     def set_change_callback(self, callback):
         if self._callback:

--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -64,6 +64,9 @@ class MPFMonitor():
         if not isinstance(self.pf_device_size, float):  # Protect against corrupted device size
             self.pf_device_size = .02
 
+        self.pf_device_alpha = self.config.get("device_alpha", 220)
+        self.pf_device_outline = self.config.get("device_outline", 3)
+
         #Command line takes priority over settings file. If command line is None, then read the settings file.
 
         #if mpf_ip_address is not in the settings file, then localhost will be used

--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -21,13 +21,13 @@ from mpfmonitor.core.modes import ModeWindow
 from mpfmonitor.core.inspector import InspectorWindow
 from mpfmonitor.core.variables import VariableWindow
 
-def run(machine_path, thread_stopper, config_file, ip_addr="localhost", port="5051", testing=False):
+def run(machine_path, thread_stopper, config_file, image_file, ip_addr="localhost", port="5051", testing=False):
     app = QApplication(sys.argv)
-    MPFMonitor(app, machine_path, thread_stopper, config_file, ip_addr, port, testing=testing)
+    MPFMonitor(app, machine_path, thread_stopper, config_file, image_file, ip_addr, port, testing=testing)
     app.exec()
 
 class MPFMonitor():
-    def __init__(self, app, machine_path, thread_stopper, config_file, ip_addr=None, port=None, parent=None, testing=False):
+    def __init__(self, app, machine_path, thread_stopper, config_file, image_file, ip_addr=None, port=None, parent=None, testing=False):
 
         # super().__init__(parent)
 
@@ -46,12 +46,13 @@ class MPFMonitor():
         self.layout = None
         self.mpf_ip_addr = ip_addr
         self.mpf_port = port
-        self.config_file = os.path.join(self.machine_path, "monitor",
-                                        config_file)
-        self.playfield_image_file = os.path.join(self.machine_path,
-                                                 "monitor", "playfield.jpg")
-        self.settings_file = os.path.join(self.machine_path,
-                                                 "monitor", "settings.ini")
+        self.config_file = os.path.join(self.machine_path, "monitor", config_file)
+
+
+        self.image_file = os.path.join(self.machine_path, "monitor", image_file)
+
+
+        self.settings_file = os.path.join(self.machine_path, "monitor", "settings.ini")
 
         QSettings.setDefaultFormat(QSettings.Format.IniFormat)
         self.local_settings = QSettings(self.settings_file, QSettings.Format.IniFormat)
@@ -113,15 +114,13 @@ class MPFMonitor():
 
         self.scene = QGraphicsScene()
 
-        self.pf = PfPixmapItem(QPixmap(self.playfield_image_file), self)
+        self.pf = PfPixmapItem(QPixmap(self.image_file), self)
         self.scene.addItem(self.pf)
 
         self.view = PfView(self.scene, self)
 
-        self.view.move(self.local_settings.value('windows/pf/pos',
-                                                 QPoint(800, 200)))
-        self.view.resize(self.local_settings.value('windows/pf/size',
-                                                   QSize(300, 600)))
+        self.view.move(self.local_settings.value('windows/pf/pos', QPoint(800, 200)))
+        self.view.resize(self.local_settings.value('windows/pf/size', QSize(300, 600)))
 
         self.event_window = EventWindow(self)
 

--- a/mpfmonitor/core/playfield.py
+++ b/mpfmonitor/core/playfield.py
@@ -3,6 +3,7 @@ import logging
 # For drag and drop vs click separation
 import time
 import math
+import ast
 
 # will change these to specific imports once code is more final
 from PyQt6.QtCore import *
@@ -26,6 +27,7 @@ class Shape(Enum):
     HEXAGON = 8
     OCTAGON = 9
     STAR = 10
+    CUSTOM = 11
 
 
 class PfView(QGraphicsView):
@@ -82,16 +84,21 @@ class PfPixmapItem(QGraphicsPixmapItem):
 
     def create_widget_from_config(self, widget, device_type, device_name):
         try:
-            x = self.mpfmon.config[device_type][device_name]['x']
-            y = self.mpfmon.config[device_type][device_name]['y']
+            config = self.mpfmon.config[device_type][device_name]
+            x = config['x']
+            y = config['y']
             default_size = self.mpfmon.pf_device_size
             default_alpha = self.mpfmon.pf_device_alpha
             default_outline = self.mpfmon.pf_device_outline
-            shape_str = self.mpfmon.config[device_type][device_name].get('shape', 'DEFAULT')
+
+            alpha = config.get('alpha', default_alpha)
+            shape_str = config.get('shape', 'DEFAULT')
+            custom_shape_points = None
+            if shape_str == 'CUSTOM':
+                custom_shape_points = config['custom_shape_points']
             shape = Shape[shape_str]
-            rotation = self.mpfmon.config[device_type][device_name].get('rotation', 0)
-            size = self.mpfmon.config[device_type][device_name].get('size', default_size)
-            alpha = self.mpfmon.config[device_type][device_name].get('alpha', default_alpha)
+            rotation = config.get('rotation', 0)
+            size = config.get('size', default_size)
 
         except KeyError:
             return
@@ -101,7 +108,7 @@ class PfPixmapItem(QGraphicsPixmapItem):
 
         self.create_pf_widget(widget, device_type, device_name, x, y,
                               size=size, alpha=alpha, rotation=rotation,
-                              shape=shape, save=False, outline=default_outline)
+                              shape=shape, save=False, outline=default_outline, custom_shape_points=custom_shape_points)
 
     def dragEnterEvent(self, event):
         event.acceptProposedAction()
@@ -125,10 +132,10 @@ class PfPixmapItem(QGraphicsPixmapItem):
 
     def create_pf_widget(self, widget, device_type, device_name, drop_x,
                          drop_y, size=None, alpha=255, rotation=0,
-                         outline=3, shape=Shape.DEFAULT, save=True):
+                         outline=3, shape=Shape.DEFAULT, save=True, custom_shape_points=None):
         w = PfWidget(self.mpfmon, widget, device_type, device_name, drop_x,
                      drop_y, size=size, alpha=alpha, rotation=rotation,
-                     outline=outline, shape_type=shape, save=save)
+                     outline=outline, shape_type=shape, save=save, custom_shape_points=custom_shape_points)
 
         self.mpfmon.scene.addItem(w)
 
@@ -137,7 +144,7 @@ class PfWidget(QGraphicsItem):
 
     def __init__(self, mpfmon, widget, device_type, device_name, x, y,
                  size=None, alpha=255, rotation=0, outline=3,
-                 shape_type=Shape.DEFAULT, save=True):
+                 shape_type=Shape.DEFAULT, save=True, custom_shape_points=None):
         super().__init__()
 
         self.widget = widget    # type: DeviceNode
@@ -150,6 +157,7 @@ class PfWidget(QGraphicsItem):
         self.angle = rotation
         self.alpha = alpha
         self.outline = outline
+        self.custom_shape_points = custom_shape_points
 
         self.setToolTip('{}: {}'.format(self.device_type, self.name))
         self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton | Qt.MouseButton.RightButton)
@@ -277,6 +285,9 @@ class PfWidget(QGraphicsItem):
         if draw_shape == Shape.CIRCLE:
             return None # Handle circles with drawEllipse instead
 
+        elif draw_shape == Shape.CUSTOM:
+            return self.custom_points()
+
         elif draw_shape == Shape.SQUARE:
             return self.square_points()
 
@@ -332,7 +343,14 @@ class PfWidget(QGraphicsItem):
         return [[0, -.3], [-.3, .7], [.3, .7]]
 
     def star_points(self):
-        return [[0, -.5], [-.11, -.15], [-.48, -.15], [-.18, .06], [-.29, .4], [0, .19], [.29, .4], [.18, .06], [.48, -.15], [.11, -.15] ]
+        return [[0, -.5], [-.11, -.15], [-.48, -.15], [-.18, .06], [-.29, .4], [0, .19], [.29, .4], [.18, .06], [.48, -.15], [.11, -.15]]
+
+    def custom_points(self):
+        '''Loads a custom vertex array from config, or falls back to an X if config is invalid or missing.'''
+        if self.custom_shape_points:
+            return self.custom_shape_points
+        else:  # fallback X
+            return [[.36, .36], [0, .19], [-.36, .36], [-.19, 0], [-.36, -.36], [0, -.19], [.36, -.36], [.19, 0]]
 
     def notify(self, destroy=False, resize=False):
         self.update()

--- a/mpfmonitor/core/playfield.py
+++ b/mpfmonitor/core/playfield.py
@@ -85,10 +85,13 @@ class PfPixmapItem(QGraphicsPixmapItem):
             x = self.mpfmon.config[device_type][device_name]['x']
             y = self.mpfmon.config[device_type][device_name]['y']
             default_size = self.mpfmon.pf_device_size
+            default_alpha = self.mpfmon.pf_device_alpha
+            default_outline = self.mpfmon.pf_device_outline
             shape_str = self.mpfmon.config[device_type][device_name].get('shape', 'DEFAULT')
             shape = Shape[shape_str]
             rotation = self.mpfmon.config[device_type][device_name].get('rotation', 0)
             size = self.mpfmon.config[device_type][device_name].get('size', default_size)
+            alpha = self.mpfmon.config[device_type][device_name].get('alpha', default_alpha)
 
         except KeyError:
             return
@@ -97,7 +100,8 @@ class PfPixmapItem(QGraphicsPixmapItem):
         y *= self.height
 
         self.create_pf_widget(widget, device_type, device_name, x, y,
-                              size=size, rotation=rotation, shape=shape, save=False)
+                              size=size, alpha=alpha, rotation=rotation,
+                              shape=shape, save=False, outline=default_outline)
 
     def dragEnterEvent(self, event):
         event.acceptProposedAction()
@@ -120,9 +124,11 @@ class PfPixmapItem(QGraphicsPixmapItem):
             self.mpfmon.log.warn("Invalid device dragged.")
 
     def create_pf_widget(self, widget, device_type, device_name, drop_x,
-                         drop_y, size=None, rotation=0, shape=Shape.DEFAULT, save=True):
+                         drop_y, size=None, alpha=255, rotation=0,
+                         outline=3, shape=Shape.DEFAULT, save=True):
         w = PfWidget(self.mpfmon, widget, device_type, device_name, drop_x,
-                     drop_y, size=size, rotation=rotation, shape_type=shape, save=save)
+                     drop_y, size=size, alpha=alpha, rotation=rotation,
+                     outline=outline, shape_type=shape, save=save)
 
         self.mpfmon.scene.addItem(w)
 
@@ -130,7 +136,8 @@ class PfPixmapItem(QGraphicsPixmapItem):
 class PfWidget(QGraphicsItem):
 
     def __init__(self, mpfmon, widget, device_type, device_name, x, y,
-                 size=None, rotation=0, shape_type=Shape.DEFAULT, save=True):
+                 size=None, alpha=255, rotation=0, outline=3,
+                 shape_type=Shape.DEFAULT, save=True):
         super().__init__()
 
         self.widget = widget    # type: DeviceNode
@@ -141,6 +148,8 @@ class PfWidget(QGraphicsItem):
         self.set_size(size=size)
         self.shape_type = shape_type
         self.angle = rotation
+        self.alpha = alpha
+        self.outline = outline
 
         self.setToolTip('{}: {}'.format(self.device_type, self.name))
         self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton | Qt.MouseButton.RightButton)
@@ -241,8 +250,8 @@ class PfWidget(QGraphicsItem):
     def paint(self, painter, option, widget=None):
         """Paint this widget to the playfield."""
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
-        painter.setPen(self.widget.get_colored_pen())
-        painter.setBrush(self.widget.get_colored_brush())
+        painter.setPen(self.widget.get_colored_pen(self.outline))
+        painter.setBrush(self.widget.get_colored_brush(self.alpha))
 
         draw_shape = self.draw_shape()
         if draw_shape == Shape.CIRCLE:

--- a/mpfmonitor/core/ui/inspector.ui
+++ b/mpfmonitor/core/ui/inspector.ui
@@ -154,6 +154,11 @@
               <string>Star</string>
              </property>
             </item>
+            <item>
+             <property name="text">
+              <string>Custom</string>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="1" column="0">

--- a/mpfmonitor/tests/test_playfield.py
+++ b/mpfmonitor/tests/test_playfield.py
@@ -170,38 +170,38 @@ class TestPfWidgetColorFuncs(unittest.TestCase):
 
     def test_colored_brush_light(self):
         color_in = [0, 128, 255]
-        expected_color_out = [0, 203, 255]  # Manually calculated 128 -> 203
+        expected_color_out = [0, 203, 255, 255]  # Manually calculated 128 -> 203
         device_type = 'light'
         mock_widget = DeviceNode()
         mock_widget.setData({"color": color_in})
         mock_widget.setType(device_type)
 
         expected_q_brush_out = QBrush(QColor(*expected_color_out), Qt.BrushStyle.SolidPattern)
-        q_brush_out = mock_widget.get_colored_brush()
+        q_brush_out = mock_widget.get_colored_brush(255)
 
         self.assertEqual(q_brush_out, expected_q_brush_out, 'Brush is not returning correct value')
 
     def test_colored_brush_switch_off(self):
         device_type = 'switch'
-        expected_color_out = [0, 0, 0]
+        expected_color_out = [0, 0, 0, 255]
         mock_widget = DeviceNode()
         mock_widget.setData({'state': False})
         mock_widget.setType(device_type)
 
         expected_q_brush_out = QBrush(QColor(*expected_color_out), Qt.BrushStyle.SolidPattern)
-        q_brush_out = mock_widget.get_colored_brush()
+        q_brush_out = mock_widget.get_colored_brush(255)
 
         self.assertEqual(q_brush_out, expected_q_brush_out, 'Brush is not returning correct value')
 
     def test_colored_brush_switch_on(self):
         device_type = 'switch'
-        expected_color_out = [0, 255, 0]
+        expected_color_out = [0, 255, 0, 255]
         mock_widget = DeviceNode()
         mock_widget.setData({'state': True})
         mock_widget.setType(device_type)
 
         expected_q_brush_out = QBrush(QColor(*expected_color_out), Qt.BrushStyle.SolidPattern)
-        q_brush_out = mock_widget.get_colored_brush()
+        q_brush_out = mock_widget.get_colored_brush(255)
 
         self.assertEqual(q_brush_out, expected_q_brush_out, 'Brush is not returning correct value')
 

--- a/mpfmonitor/tests/test_playfield.py
+++ b/mpfmonitor/tests/test_playfield.py
@@ -8,41 +8,6 @@ class TestablePfWidgetNonDrawn(PfWidget):
         if mpfmon_mock is not None:
             self.mpfmon = mpfmon_mock
 
-    """
-    __init__ of PfWidget:
-
-
-    def __init__(self, mpfmon, widget, device_type, device_name, x, y,
-                 size=None, rotation=0, shape=Shape.DEFAULT, save=True):
-        super().__init__()
-
-        self.widget = widget
-        self.mpfmon = mpfmon
-        self.name = device_name
-        self.move_in_progress = True
-        self.device_type = device_type
-        self.set_size(size=size)
-        self.shape_type = shape
-        self.angle = rotation
-
-        self.setToolTip('{}: {}'.format(self.device_type, self.name))
-        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton | Qt.MouseButton.RightButton)
-        self.setPos(x, y)
-        self.update_pos(save)
-        self.click_start = 0
-        self.release_switch = False
-
-        self.log = logging.getLogger('Core')
-
-        old_widget_exists = widget.set_change_callback(self.notify)
-
-        if old_widget_exists:
-            self.log.debug("Previous widget exists.")
-            old_widget_exists(destroy=True)
-
-        """
-
-
 class TestPfWidgetParameters(unittest.TestCase):
 
     def setUp(self):
@@ -118,23 +83,6 @@ class TestPfWidgetResizeToDefault(unittest.TestCase):
         self.config = MagicMock()
         self.mock_mpfmon.config[self.widget.device_type].get.return_value = self.config
         self.config.get.return_value = None
-
-        """
-        def resize_to_default(self, force=False):
-        device_config = self.mpfmon.config[self.device_type].get(self.name, None)
-
-        if force:
-            device_config.pop('size', None) # Delete saved size info, None is incase key doesn't exist (popped twice)
-
-        device_size = device_config.get('size', None)
-
-        if device_size is not None:
-            # Do not change the size if it's already set
-            pass
-        elif device_config is not None:
-            self.set_size()
-
-        self.update_pos(save=False)  # Do not save at this point. Let it be saved elsewhere. This reduces writes."""
 
     def test_size_resize_to_default(self):
         self.widget.resize_to_default()


### PR DESCRIPTION
Adds support to allow more flexibility for developers.

- adds -i CLI param with simple image filename (NOT path relative to command execution, but rather relative to `<game>/monitor/`)
- adds `device_outline` root level param to change from default of 3 pixel outlines
- adds `device_alpha` root level param to change from NEW alpha default of 220. Values are ints between 0-255
- adds device-level `alpha` param to override the alpha for just that device
- adds `shape: CUSTOM` support, with user-managed `custom_shape_points` param, and a default fallback `X` shape.
-- shape points should be generally fit to within -0.5 and 0.5 for X and Y, and instead the `size:` option should be used to scale to larger sizes.

To use all these features, your yaml file might look like:

```yaml
device_alpha: 210
device_outline: 2
light:
  l_my_light:
    x: 0.05
    y: 0.03
    size: 0.08
    shape: CUSTOM
    custom_shape_points: [[0,0], [.3,.3], [.3,-.3]]
```
