### PR TITLE
change non-lights to Others and dont make it affect switches anymore

### DIFF
--- a/mpfmonitor/core/inspector.py
+++ b/mpfmonitor/core/inspector.py
@@ -98,7 +98,7 @@ class InspectorWindow(QWidget):
 
     def attach_layer_tab_signals(self):
         self._attach_button_signal(self.ui.toggle_lights_button, self.mpfmon.toggle_layer_lights_action)
-        self._attach_button_signal(self.ui.toggle_nonlights_button, self.mpfmon.toggle_layer_nonlights_action)
+        self._attach_button_signal(self.ui.toggle_others_button, self.mpfmon.toggle_layer_others_action)
         self._attach_button_signal(self.ui.toggle_switches_button, self.mpfmon.toggle_layer_switches_action)
         self._attach_button_signal(self.ui.toggle_pf_image_button, self.mpfmon.toggle_layer_pf_image_action)
 

--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -47,7 +47,7 @@ class MPFMonitor():
         self.mpf_ip_addr = ip_addr
         self.mpf_port = port
         self.hide_layer_lights = False
-        self.hide_layer_nonlights = False
+        self.hide_layer_others = False
         self.hide_layer_switches = False
         self.device_name_filter = ''
 
@@ -120,17 +120,17 @@ class MPFMonitor():
         self.toggle_layer_lights_action.setCheckable(True)
         self.toggle_layer_lights_action.setChecked(True)
 
-        self.toggle_layer_nonlights_action = QAction('&Non-Lights', self.device_window,
-                                        statusTip='Show non-light devices',
-                                        triggered=self.toggle_layer_nonlights)
-        self.toggle_layer_nonlights_action.setCheckable(True)
-        self.toggle_layer_nonlights_action.setChecked(True)
-
         self.toggle_layer_switches_action = QAction('&Switches', self.device_window,
                                         statusTip='Show switch devices',
                                         triggered=self.toggle_layer_switches)
         self.toggle_layer_switches_action.setCheckable(True)
         self.toggle_layer_switches_action.setChecked(True)
+
+        self.toggle_layer_others_action = QAction('&Others', self.device_window,
+                                        statusTip='Show other devices',
+                                        triggered=self.toggle_layer_others)
+        self.toggle_layer_others_action.setCheckable(True)
+        self.toggle_layer_others_action.setChecked(True)
 
         self.toggle_layer_pf_image_action = QAction('&Background', self.device_window,
                                         statusTip='Show the playfield image',
@@ -242,8 +242,8 @@ class MPFMonitor():
         """)
 
         layers_toolbar.addAction(self.toggle_layer_lights_action)
-        layers_toolbar.addAction(self.toggle_layer_nonlights_action)
         layers_toolbar.addAction(self.toggle_layer_switches_action)
+        layers_toolbar.addAction(self.toggle_layer_others_action)
         layers_toolbar.addAction(self.toggle_layer_pf_image_action)
         layers_toolbar.addSeparator()
         layers_toolbar.addAction(self.pf_device_filter_action)
@@ -299,12 +299,12 @@ class MPFMonitor():
         self.hide_layer_lights = not self.toggle_layer_lights_action.isChecked()
         self.scene.update()
 
-    def toggle_layer_nonlights(self):
-        self.hide_layer_nonlights = not self.toggle_layer_nonlights_action.isChecked()
-        self.scene.update()
-
     def toggle_layer_switches(self):
         self.hide_layer_switches = not self.toggle_layer_switches_action.isChecked()
+        self.scene.update()
+
+    def toggle_layer_others(self):
+        self.hide_layer_others = not self.toggle_layer_others_action.isChecked()
         self.scene.update()
 
     def toggle_variables_window(self):

--- a/mpfmonitor/core/playfield.py
+++ b/mpfmonitor/core/playfield.py
@@ -236,10 +236,10 @@ class PfWidget(QGraphicsItem):
         if self.device_type == 'light' and self.mpfmon.hide_layer_lights:
             return False
 
-        if self.device_type != 'light' and self.mpfmon.hide_layer_nonlights:
+        if self.device_type == 'switch' and self.mpfmon.hide_layer_switches:
             return False
 
-        if self.device_type == 'switch' and self.mpfmon.hide_layer_switches:
+        if self.device_type != 'light' and self.device_type != 'switch' and self.mpfmon.hide_layer_others:
             return False
 
         return True

--- a/mpfmonitor/core/ui/inspector.ui
+++ b/mpfmonitor/core/ui/inspector.ui
@@ -455,9 +455,9 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_5">
          <item>
-          <widget class="QCheckBox" name="toggle_nonlights_button">
+          <widget class="QCheckBox" name="toggle_switches_button">
            <property name="text">
-            <string>Toggle Non-Lights</string>
+            <string>Switches</string>
            </property>
           </widget>
          </item>
@@ -466,9 +466,9 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_6">
          <item>
-          <widget class="QCheckBox" name="toggle_switches_button">
+          <widget class="QCheckBox" name="toggle_others_button">
            <property name="text">
-            <string>Switches</string>
+            <string>Other Devices</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
NonLights overlapping with Switches wasnt a good experience, so lets just make Others a group, so the two most common groups (lights and switches) can be isolated.