### PR TITLE
Event window improvements

### DIFF
--- a/mpfmonitor/core/events.py
+++ b/mpfmonitor/core/events.py
@@ -43,6 +43,7 @@ class EventWindow(QWidget):
         self.ui.filterLineEdit.textChanged.connect(self.filter_text)
         self.ui.sortComboBox.currentIndexChanged.connect(self.change_sort)
         self.ui.clear_button.clicked.connect(self.clear_log)
+        self.ui.inject_button.clicked.connect(self.trigger_text_event)
 
     def attach_model(self):
         self.model = QStandardItemModel(0, 3)
@@ -102,6 +103,17 @@ class EventWindow(QWidget):
     def clear_log(self):
         #clears the log of events
         self.model.removeRows(0, self.model.rowCount())
+
+    def trigger_text_event(self):
+        """Send a name-only event from the event window field to MPF."""
+        event_name = self.ui.inject_text.text().strip()
+        payload_kwargs = {}
+
+        if event_name:
+            self.mpfmon.bcp.send('trigger', name=event_name, **payload_kwargs)
+
+        self.ui.inject_text.clear()
+        self.ui.inject_text.setFocus()
 
     def closeEvent(self, event):
         self.mpfmon.write_local_settings()

--- a/mpfmonitor/core/events.py
+++ b/mpfmonitor/core/events.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from PyQt6.QtCore import *
 from PyQt6.QtGui import *
 from PyQt6.QtWidgets import *
@@ -56,7 +58,6 @@ class EventWindow(QWidget):
         self.change_sort()  # Default sort
 
         self.ui.tableView.setModel(self.filtered_model)
-        self.ui.tableView.setColumnHidden(2, True)
         self.rootNode = self.model.invisibleRootItem()
 
     def add_event_to_model(self, event_name, event_type, event_callback,
@@ -68,7 +69,8 @@ class EventWindow(QWidget):
 
         name = QStandardItem(event_name)
         kwargs = QStandardItem(str(event_kwargs))
-        time_added = QStandardItem(str(self.added_index).zfill(10))
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        time_added = QStandardItem(current_time)
         self.added_index += 1
         self.model.insertRow(0, [name, kwargs, time_added])
 
@@ -78,7 +80,6 @@ class EventWindow(QWidget):
         self.ui.tableView.resizeColumnToContents(1)
 
         if not self.already_hidden:
-            self.ui.tableView.setColumnHidden(2, True)
             self.already_hidden = True
 
     def filter_text(self, string):

--- a/mpfmonitor/core/events.py
+++ b/mpfmonitor/core/events.py
@@ -28,10 +28,8 @@ class EventWindow(QWidget):
 
         self.ui.setWindowTitle('Events')
 
-        self.ui.move(self.mpfmon.local_settings.value('windows/events/pos',
-                                                   QPoint(500, 200)))
-        self.ui.resize(self.mpfmon.local_settings.value('windows/events/size',
-                                                     QSize(300, 600)))
+        self.ui.move(self.mpfmon.local_settings.value('windows/events/pos', QPoint(500, 200)))
+        self.ui.resize(self.mpfmon.local_settings.value('windows/events/size', QSize(300, 600)))
 
         # Disable option "Sort", select first item.
         # TODO: Store and load selected sort index to local_settings
@@ -45,11 +43,10 @@ class EventWindow(QWidget):
         self.ui.clear_button.clicked.connect(self.clear_log)
 
     def attach_model(self):
-        self.model = QStandardItemModel(0, 2)
-
+        self.model = QStandardItemModel(0, 3)
         self.model.setHeaderData(0, Qt.Orientation.Horizontal, "Event")
         self.model.setHeaderData(1, Qt.Orientation.Horizontal, "Data")
-        # self.model.setHeaderData(2, Qt.Orientation.Horizontal, "Time")
+        self.model.setHeaderData(2, Qt.Orientation.Horizontal, "Time")
 
         self.filtered_model = QSortFilterProxyModel(self)
         self.filtered_model.setSourceModel(self.model)
@@ -103,7 +100,7 @@ class EventWindow(QWidget):
 
     def clear_log(self):
         #clears the log of events
-        self.model.clear()
+        self.model.removeRows(0, self.model.rowCount())
 
     def closeEvent(self, event):
         self.mpfmon.write_local_settings()

--- a/mpfmonitor/core/ui/searchable_table.ui
+++ b/mpfmonitor/core/ui/searchable_table.ui
@@ -31,7 +31,24 @@
      <property name="verticalSpacing">
       <number>5</number>
      </property>
-     <item row="1" column="0">
+     <item row="1" column="0" colspan="2">
+      <widget class="QLineEdit" name="inject_text">
+       <property name="placeholderText">
+        <string>Event name</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="inject_button">
+       <property name="text">
+        <string>Send Event</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
       <widget class="QLineEdit" name="filterLineEdit">
        <property name="text">
         <string/>
@@ -44,7 +61,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="QComboBox" name="sortComboBox">
        <item>
         <property name="text">
@@ -73,7 +90,14 @@
        </item>
       </widget>
      </item>
-     <item row="2" column="0" colspan="2">
+     <item row="2" column="2" alignment="Qt::AlignLeft">
+      <widget class="QPushButton" name="clear_button">
+       <property name="text">
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="3">
       <widget class="QTableView" name="tableView">
        <property name="enabled">
         <bool>true</bool>
@@ -129,13 +153,6 @@
        <attribute name="verticalHeaderMinimumSectionSize">
         <number>20</number>
        </attribute>
-      </widget>
-     </item>
-     <item row="0" column="0" alignment="Qt::AlignLeft">
-      <widget class="QPushButton" name="clear_button">
-       <property name="text">
-        <string>Clear</string>
-       </property>
       </widget>
      </item>
     </layout>

--- a/mpfmonitor/tests/test_events.py
+++ b/mpfmonitor/tests/test_events.py
@@ -171,6 +171,12 @@ class TestEvents(unittest.TestCase):
         self.eventWindow.ui.filterLineEdit.setText(event_list[2])
         self.assertEqual(self.eventWindow.filtered_model.rowCount(), 2)
 
+    def test_ui_injection_flow(self):
+        self.eventWindow.ui.inject_text.setText("fake_event")
+        QTest.mouseClick(self.eventWindow.ui.inject_button, QtCore.Qt.MouseButton.LeftButton)
+        self.eventWindow.mpfmon.bcp.send.assert_called_with('trigger', name="fake_event")
+        self.assertEqual(self.eventWindow.ui.inject_text.text(), "")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mpfmonitor/tests/test_events.py
+++ b/mpfmonitor/tests/test_events.py
@@ -1,6 +1,8 @@
-import unittest
-import threading
 import sys
+import threading
+import time
+import unittest
+
 from PyQt6.QtTest import QTest
 from PyQt6 import QtCore, QtGui, QtWidgets
 from unittest.mock import MagicMock
@@ -120,6 +122,7 @@ class TestEvents(unittest.TestCase):
         event_list = ["event_a", "event_b", "event_c"]
 
         for e in event_list:
+            time.sleep(0.002) # need to ensure events have different timestamps
             self.eventWindow.add_event_to_model(e, None, None, self.mock_event_kwargs, None)
 
         # Default is Received up


### PR DESCRIPTION
- Clearing events now doesnt nuke the header row
- Move Clear button to same row as Filter/Sort
- Show the third column in the event list table, for timestamp received (BCP does not transport event times from MPF)
- Add text field and button to submit simple text name only events back to MPF