### PR TITLE
Persist sort options and default devices to alpha, add -is option

### DIFF
--- a/mpfmonitor/commands/monitor.py
+++ b/mpfmonitor/commands/monitor.py
@@ -53,6 +53,10 @@ class Command(object):
                                  "Use `-i=image1.jpg -i=image2.png` to add multiple options.\n"
                                  "Supported types: PNG, JPG, BMP, GIF")
 
+        parser.add_argument("-is",
+                            action="store_true", dest="all_images",
+                            default=False, help="Load all PNG, JPG, BMP, GIF files in '<game>/monitor/'")
+
         parser.add_argument("-v",
                             action="store_const", dest="loglevel", const=logging.DEBUG,
                             default=logging.INFO, help="Enables verbose logging to the log file")
@@ -107,11 +111,29 @@ class Command(object):
 
         thread_stopper = threading.Event()
 
+        resolved_images = list(args.image_files)
+
+        # Handle automatic folder scanning if `-is` flag is provided
+        if args.all_images:
+            monitor_dir = os.path.join(machine_path, 'monitor')
+            valid_exts = ('.png', '.jpg', '.jpeg', '.bmp', '.gif')
+            if os.path.exists(monitor_dir):
+                discovered = [
+                    entry.name for entry in os.scandir(monitor_dir)
+                    if entry.is_file() and entry.name.lower().endswith(valid_exts)
+                ]
+                resolved_images.extend(discovered)
+
+        if not resolved_images:
+            resolved_images = ["playfield.jpg"]
+        else:
+            resolved_images.sort(key=lambda path: os.path.basename(path).lower())
+
         try:
             run(machine_path=machine_path,
                 thread_stopper=thread_stopper,
                 config_file=args.configfile,
-                image_files=args.image_files or ["playfield.jpg"],
+                image_files=resolved_images,
                 ip_addr=args.mpfipaddr,
                 port=args.mpfport)
             logging.info("MPF Monitor run loop ended.")

--- a/mpfmonitor/commands/monitor.py
+++ b/mpfmonitor/commands/monitor.py
@@ -44,13 +44,13 @@ class Command(object):
                                  "not an MPF config.yaml. Default is monitor.")
 
         parser.add_argument("-i",
-                            action="append", dest="image_files",
+                            action="extend", nargs="+", dest="image_files",
                             default=[],  # Default for lists must be implemented by custom check
                             metavar='image_files',
                             help="The MPF Monitor image file name. "
                                  "Files must be placed within the folder '<game>/monitor/' "
                                  "Default is playfield.jpg\n"
-                                 "Use `-i=image1.jpg -i=image2.png` to add multiple options.\n"
+                                 "Use `-i=image1.jpg image2.png` to add multiple options.\n"
                                  "Supported types: PNG, JPG, BMP, GIF")
 
         parser.add_argument("-is",

--- a/mpfmonitor/core/devices.py
+++ b/mpfmonitor/core/devices.py
@@ -332,7 +332,6 @@ class DeviceWindow(QWidget):
         self._debug_enabled = self.log.isEnabledFor(logging.DEBUG)
 
     def draw_ui(self):
-        # Load ui file from ./ui/
         ui_path = os.path.join(os.path.dirname(__file__), "ui", "searchable_tree.ui")
         self.ui = uic.loadUi(ui_path, self)
 
@@ -341,10 +340,11 @@ class DeviceWindow(QWidget):
         self.ui.move(self.mpfmon.local_settings.value('windows/devices/pos', QPoint(200, 200)))
         self.ui.resize(self.mpfmon.local_settings.value('windows/devices/size', QSize(300, 600)))
 
-        # Disable option "Sort", select first item.
-        # TODO: Store and load selected sort index to local_settings
         self.ui.sortComboBox.model().item(0).setEnabled(False)
-        self.ui.sortComboBox.setCurrentIndex(3)
+
+        initial_sort = int(self.mpfmon.local_settings.value('windows/devices/sort_index', 3))
+        self.ui.sortComboBox.setCurrentIndex(initial_sort)
+
         self.ui.treeView.setAlternatingRowColors(True)
 
     def attach_signals(self):
@@ -418,8 +418,7 @@ class DeviceWindow(QWidget):
         self.model.layoutAboutToBeChanged.emit()
         self.filtered_model.beginResetModel()
 
-        # This is a bit sloppy and probably should be reworked.
-        if index == 1:  # Received up
+        if index == 1:    # Received up
             self.filtered_model.sort(2, Qt.SortOrder.AscendingOrder)
         elif index == 2:  # Received down
             self.filtered_model.sort(2, Qt.SortOrder.DescendingOrder)

--- a/mpfmonitor/core/devices.py
+++ b/mpfmonitor/core/devices.py
@@ -344,7 +344,7 @@ class DeviceWindow(QWidget):
         # Disable option "Sort", select first item.
         # TODO: Store and load selected sort index to local_settings
         self.ui.sortComboBox.model().item(0).setEnabled(False)
-        self.ui.sortComboBox.setCurrentIndex(1)
+        self.ui.sortComboBox.setCurrentIndex(3)
         self.ui.treeView.setAlternatingRowColors(True)
 
     def attach_signals(self):
@@ -359,6 +359,7 @@ class DeviceWindow(QWidget):
         self.treeview = self.ui.treeView
 
         self.model = QStandardItemModel()
+        self.model.setColumnCount(3)
         self.model.setHorizontalHeaderLabels(["Device", "Data"])
 
         self.treeview.setDragDropMode(QAbstractItemView.DragDropMode.DragOnly)
@@ -370,9 +371,12 @@ class DeviceWindow(QWidget):
         self.filtered_model = QSortFilterProxyModel(self)
         self.filtered_model.setSourceModel(self.model)
         self.filtered_model.setRecursiveFilteringEnabled(True)
+        self.filtered_model.setDynamicSortFilter(True)
         self.filtered_model.setFilterCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
 
         self.treeview.setModel(self.filtered_model)
+        self.filtered_model.sort(0, Qt.SortOrder.AscendingOrder)
+        self.ui.treeView.setColumnHidden(2, True)
 
     def resize_columns_to_content(self):
         self.ui.treeView.resizeColumnToContents(0)
@@ -404,8 +408,6 @@ class DeviceWindow(QWidget):
         else:
             self.device_states[type][name].setData(state)
 
-        self.ui.treeView.setColumnHidden(2, True)
-
     def filter_text(self, string):
         wc_string = "*" + str(string) + "*"
         self.filtered_model.setFilterWildcard(wc_string)
@@ -427,6 +429,7 @@ class DeviceWindow(QWidget):
             self.filtered_model.sort(0, Qt.SortOrder.DescendingOrder)
 
         self.filtered_model.endResetModel()
+        self.ui.treeView.setColumnHidden(2, True)
         self.model.layoutChanged.emit()
 
     def closeEvent(self, event):

--- a/mpfmonitor/core/events.py
+++ b/mpfmonitor/core/events.py
@@ -26,7 +26,6 @@ class EventWindow(QWidget):
         self.added_index = 0
 
     def draw_ui(self):
-        # Load ui file from ./ui/
         ui_path = os.path.join(os.path.dirname(__file__), "ui", "events_table.ui")
         self.ui = uic.loadUi(ui_path, self)
 
@@ -35,10 +34,10 @@ class EventWindow(QWidget):
         self.ui.move(self.mpfmon.local_settings.value('windows/events/pos', QPoint(500, 200)))
         self.ui.resize(self.mpfmon.local_settings.value('windows/events/size', QSize(300, 600)))
 
-        # Disable option "Sort", select first item.
-        # TODO: Store and load selected sort index to local_settings
+        initial_sort = int(self.mpfmon.local_settings.value('windows/events/sort_index', 1))
+        self.ui.sortComboBox.setCurrentIndex(initial_sort)
+
         self.ui.sortComboBox.model().item(0).setEnabled(False)
-        self.ui.sortComboBox.setCurrentIndex(1)
 
     def attach_signals(self):
         assert (self.ui is not None)
@@ -59,7 +58,8 @@ class EventWindow(QWidget):
         self.filtered_model.setFilterKeyColumn(0)
         self.filtered_model.setDynamicSortFilter(True)
 
-        self.change_sort()  # Default sort
+        initial_sort = int(self.mpfmon.local_settings.value('windows/events/sort_index', 1))
+        self.change_sort(initial_sort)
 
         self.ui.tableView.setModel(self.filtered_model)
         self.rootNode = self.model.invisibleRootItem()
@@ -92,8 +92,7 @@ class EventWindow(QWidget):
         self.ui.tableView.resizeColumnToContents(1)
 
     def change_sort(self, index=1):
-        # This is a bit sloppy and probably should be reworked.
-        if index == 1:  # Received up
+        if index == 1:    # Received up
             self.filtered_model.sort(2, Qt.SortOrder.DescendingOrder)
         elif index == 2:  # Received down
             self.filtered_model.sort(2, Qt.SortOrder.AscendingOrder)

--- a/mpfmonitor/core/modes.py
+++ b/mpfmonitor/core/modes.py
@@ -34,11 +34,9 @@ class ModeWindow(QWidget):
         self.ui.sortComboBox.setItemText(1, "Priority ▴")
         self.ui.sortComboBox.setItemText(2, "Priority ▾")
 
-
-        # Disable option "Sort", select first item.
-        # TODO: Store and load selected sort index to local_settings
         self.ui.sortComboBox.model().item(0).setEnabled(False)
-        self.ui.sortComboBox.setCurrentIndex(1)
+        initial_sort = int(self.mpfmon.local_settings.value('windows/modes/sort_index', 1))
+        self.ui.sortComboBox.setCurrentIndex(initial_sort)
 
     def attach_signals(self):
         assert (self.ui is not None)
@@ -46,7 +44,7 @@ class ModeWindow(QWidget):
         self.ui.sortComboBox.currentIndexChanged.connect(self.change_sort)
 
     def attach_model(self):
-        self.model = QStandardItemModel(0, 2)
+        self.model = QStandardItemModel(0, 3)
 
         self.model.setHeaderData(0, Qt.Orientation.Horizontal, "Mode")
         self.model.setHeaderData(1, Qt.Orientation.Horizontal, "Priority")
@@ -56,7 +54,8 @@ class ModeWindow(QWidget):
         self.filtered_model.setFilterKeyColumn(0)
         self.filtered_model.setDynamicSortFilter(True)
 
-        self.change_sort()  # Default sort
+        initial_sort = int(self.mpfmon.local_settings.value('windows/modes/sort_index', 1))
+        self.change_sort(initial_sort)
 
         self.ui.tableView.setModel(self.filtered_model)
         self.ui.tableView.setColumnHidden(2, True)
@@ -85,8 +84,7 @@ class ModeWindow(QWidget):
         self.ui.tableView.resizeColumnToContents(1)
 
     def change_sort(self, index=1):
-        # This is a bit sloppy and probably should be reworked.
-        if index == 1:  # Received up
+        if index == 1:    # Received up
             self.filtered_model.sort(2, Qt.SortOrder.DescendingOrder)
         elif index == 2:  # Received down
             self.filtered_model.sort(2, Qt.SortOrder.AscendingOrder)

--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -52,8 +52,12 @@ class MPFMonitor():
         self.device_name_filter = ''
 
         self.config_file = os.path.join(self.machine_path, "monitor", config_file)
-        self.image_files = [os.path.join(self.machine_path, "monitor", f) for f in image_files]
         self.settings_file = os.path.join(self.machine_path, "monitor", "settings.ini")
+
+        resolved = [os.path.abspath(os.path.join(self.machine_path, "monitor", f)) for f in image_files]
+        deduped = list(dict.fromkeys(resolved))
+        deduped.sort(key=lambda path: os.path.basename(path).lower())
+        self.image_files = deduped
 
         QSettings.setDefaultFormat(QSettings.Format.IniFormat)
         self.local_settings = QSettings(self.settings_file, QSettings.Format.IniFormat)

--- a/mpfmonitor/core/mpfmon.py
+++ b/mpfmonitor/core/mpfmon.py
@@ -416,6 +416,10 @@ class MPFMonitor():
             'size': window.size(),
             'visible': window.isVisible()
         }
+
+        if hasattr(window, 'ui') and window.ui and hasattr(window.ui, 'sortComboBox'):
+            settings['sort_index'] = window.ui.sortComboBox.currentIndex()
+
         for line in settings.keys():
             setting_name = 'windows/' + window_name + '/' + line
             self.local_settings.setValue(setting_name, settings.get(line))

--- a/mpfmonitor/core/variables.py
+++ b/mpfmonitor/core/variables.py
@@ -23,7 +23,6 @@ class VariableWindow(QWidget):
         self.variables = dict()  # keys are tuples of (variable, type), values are the var's value model
 
     def draw_ui(self):
-        # Load ui file from ./ui/
         ui_path = os.path.join(os.path.dirname(__file__), "ui", "searchable_table.ui")
         self.ui = uic.loadUi(ui_path, self)
 
@@ -38,11 +37,9 @@ class VariableWindow(QWidget):
         self.ui.sortComboBox.setItemText(3, "Value ▴")
         self.ui.sortComboBox.setItemText(4, "Value ▾")
 
-        # Disable option "Sort", select first item.
-        # TODO: Store and load selected sort index to local_settings
         self.ui.sortComboBox.model().item(0).setEnabled(False)
-        self.ui.sortComboBox.setCurrentIndex(1)
-
+        initial_sort = int(self.mpfmon.local_settings.value('windows/variables/sort_index', 1))
+        self.ui.sortComboBox.setCurrentIndex(initial_sort)
 
     def attach_signals(self):
         assert (self.ui is not None)
@@ -62,7 +59,8 @@ class VariableWindow(QWidget):
         self.filtered_model.setFilterKeyColumn(1)
         self.filtered_model.setDynamicSortFilter(True)
 
-        self.change_sort()  # Default sort
+        initial_sort = int(self.mpfmon.local_settings.value('windows/variables/sort_index', 1))
+        self.change_sort(initial_sort)
 
         self.ui.tableView.setModel(self.filtered_model)
         # self.ui.tableView.setColumnHidden(2, True)
@@ -91,8 +89,7 @@ class VariableWindow(QWidget):
         self.ui.tableView.resizeColumnToContents(1)
 
     def change_sort(self, index=1):
-        # This is a bit sloppy and probably should be reworked.
-        if index == 1:  # Name up
+        if index == 1:    # Name up
             self.filtered_model.sort(1, Qt.SortOrder.DescendingOrder)
         elif index == 2:  # Name down
             self.filtered_model.sort(1, Qt.SortOrder.AscendingOrder)

--- a/mpfmonitor/tests/test_events.py
+++ b/mpfmonitor/tests/test_events.py
@@ -79,7 +79,7 @@ class TestEvents(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         mock_mpfmon = MagicMock()
-        mock_mpfmon.local_settings.value.side_effect = [QPoint(500, 200), QSize(300, 600)]
+        mock_mpfmon.local_settings.value.side_effect = lambda key, default=None: default
 
         self.eventWindow = EventWindow(mock_mpfmon)
 

--- a/mpfmonitor/tests/test_modes.py
+++ b/mpfmonitor/tests/test_modes.py
@@ -82,7 +82,7 @@ class TestModeWindowGUI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         mock_mpfmon = MagicMock()
-        mock_mpfmon.local_settings.value.side_effect = [QPoint(1100, 200), QSize(300, 250)]
+        mock_mpfmon.local_settings.value.side_effect = lambda key, default=None: default
 
         self.mode_window = ModeWindow(mock_mpfmon)
 


### PR DESCRIPTION
`mpf monitor -is` will load all images of the supported types (jpg bmp png gif (single frame)) from the monitor folder into the playfield image set. Use this option instead of `-i imagename`.
Note: images are always alpha sorted, so the start image will be the first one alphabetically (case-insensitive)